### PR TITLE
fix(security): harden GitHub Actions workflows against expression injection

### DIFF
--- a/.github/workflows/chaos-test-full.yml
+++ b/.github/workflows/chaos-test-full.yml
@@ -62,6 +62,8 @@ jobs:
           echo "✅ Prometheus is ready for chaos test"
 
       - name: Run Jepsen + Chaos test
+        env:
+          CHAOS_DURATION: ${{ inputs.chaos_duration || '300' }}
         run: |
           export KUBECONFIG=/tmp/cnpg-playground/k8s/kube-config.yaml
           export LITMUS_NAMESPACE=litmus
@@ -70,10 +72,10 @@ jobs:
           echo "=== Starting Jepsen + Chaos Test ==="
           echo "Cluster: pg-eu"
           echo "Namespace: app"
-          echo "Chaos duration: ${{ inputs.chaos_duration || '300' }} seconds"
+          echo "Chaos duration: ${CHAOS_DURATION} seconds"
           echo ""
 
-          ./scripts/run-jepsen-chaos-test.sh pg-eu app ${{ inputs.chaos_duration || '300' }}
+          ./scripts/run-jepsen-chaos-test.sh pg-eu app "${CHAOS_DURATION}"
 
       - name: Collect test results
         if: always()


### PR DESCRIPTION
Move `${{ }}` expressions from `run:` blocks into step-level `env:` blocks, then reference them as properly-quoted shell variables.

Part of cloudnative-pg/cloudnative-pg#10113

Assisted-by: Claude Opus 4.6